### PR TITLE
Respond to github fix request

### DIFF
--- a/js/roadPieces.js
+++ b/js/roadPieces.js
@@ -43,10 +43,10 @@ export const RoadPieces = {
 // Get connections for a road end based on direction
 export function getRoadEndConnections(direction) {
     return {
-        north: direction === 'south',
-        south: direction === 'north',
-        east: direction === 'west',
-        west: direction === 'east'
+        north: direction === 'north',
+        south: direction === 'south',
+        east: direction === 'east',
+        west: direction === 'west'
     };
 }
 


### PR DESCRIPTION
Fixes inverted logic in `getRoadEndConnections` to correctly validate road connections and enable the simulation button.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca03ea8a-0557-445c-98a6-13ec5282ba6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ca03ea8a-0557-445c-98a6-13ec5282ba6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

